### PR TITLE
Fixing go.mod v2 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 Scan standard lib database rows directly to structs or slices. 
 For the most comprehensive and up-to-date docs see the [godoc](https://godoc.org/github.com/blockloop/scan)
 
+```go
+import "github.com/blockloop/scan/v2"
+```
+
 ## Examples
 
 ### Multiple Rows

--- a/bench_scanner_test.go
+++ b/bench_scanner_test.go
@@ -3,7 +3,7 @@ package scan_test
 import (
 	"testing"
 
-	"github.com/blockloop/scan"
+	"github.com/blockloop/scan/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/example_scanner_test.go
+++ b/example_scanner_test.go
@@ -7,7 +7,7 @@ import (
 	"math/rand"
 	"os"
 
-	"github.com/blockloop/scan"
+	"github.com/blockloop/scan/v2"
 	_ "github.com/proullon/ramsql/driver"
 )
 

--- a/examples_values_columns_test.go
+++ b/examples_values_columns_test.go
@@ -3,7 +3,7 @@ package scan_test
 import (
 	"fmt"
 
-	"github.com/blockloop/scan"
+	"github.com/blockloop/scan/v2"
 )
 
 func ExampleValues() {

--- a/fakes_test.go
+++ b/fakes_test.go
@@ -6,7 +6,7 @@ import (
 	sync "sync"
 	"testing"
 
-	scan "github.com/blockloop/scan"
+	scan "github.com/blockloop/scan/v2"
 )
 
 func fakeRowsWithColumns(t testing.TB, rowCnt int, cols ...string) *FakeRowsScanner {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/blockloop/scan
+module github.com/blockloop/scan/v2
 
 go 1.17
 

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/blockloop/scan"
+	"github.com/blockloop/scan/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -311,6 +311,7 @@ func TestRowStrictScansNestedFields(t *testing.T) {
 	assert.Equal(t, "Brett", res.Item.First)
 	assert.Equal(t, "Jones", res.Item.Last)
 }
+
 func TestRowsStrictIgnoresFieldsWithoutDBTag(t *testing.T) {
 	rows := fakeRowsWithRecords(t, []string{"First", "Last"},
 		[]interface{}{"Brett", "Jones"},


### PR DESCRIPTION
Currently the v2 version cannot be used due to incorrect `go.mod` (see for example #34 ).

When upgrading to a major version a change in import path is also required (see [here](https://go.dev/doc/modules/release-workflow#breaking)).

In order for this to work **this should be re-tagged as v2.0.0 after merge**.