### PR TITLE
Implement nested structs for columns and values

### DIFF
--- a/columns.go
+++ b/columns.go
@@ -97,6 +97,18 @@ func columns(v interface{}, strict bool, excluded ...string) ([]string, error) {
 			if tag != "-" && !isExcluded(tag) {
 				names = append(names, tag)
 			}
+
+			if typeField.Type.Kind() != reflect.Struct {
+				continue
+			}
+		}
+
+		if typeField.Type.Kind() == reflect.Struct {
+			embeddedNames, err := columns(valField.Addr().Interface(), strict, excluded...)
+			if err != nil {
+				return nil, err
+			}
+			names = append(names, embeddedNames...)
 			continue
 		}
 

--- a/columns_test.go
+++ b/columns_test.go
@@ -123,7 +123,7 @@ func TestColumnsStrictDoesNotAddComplexTypesWhenNoStructTag(t *testing.T) {
 	assert.EqualValues(t, []string{}, cols)
 }
 
-func TestColumnsStrictDoesNotAddComplexTypesWhenStructTagIgnored(t *testing.T) {
+func TestColumnsStrictAddsComplexTypesRegardlessOfStructTag(t *testing.T) {
 	type person struct {
 		Address struct {
 			Street string `db:"address.street"`
@@ -132,7 +132,7 @@ func TestColumnsStrictDoesNotAddComplexTypesWhenStructTagIgnored(t *testing.T) {
 
 	cols, err := ColumnsStrict(&person{})
 	assert.NoError(t, err)
-	assert.EqualValues(t, []string{}, cols)
+	assert.EqualValues(t, []string{"address.street"}, cols)
 }
 
 func TestColumnsIgnoresComplexTypesWhenNoStructTag(t *testing.T) {

--- a/columns_test.go
+++ b/columns_test.go
@@ -63,16 +63,76 @@ func TestColumnsIgnoresPrivateFields(t *testing.T) {
 	assert.EqualValues(t, []string{"Age"}, cols)
 }
 
-func TestColumnsAddsComplexTypesWhenStructTag(t *testing.T) {
+func TestColumnsAddsComplexTypesWhenNoStructTag(t *testing.T) {
 	type person struct {
 		Address struct {
 			Street string
+		}
+	}
+
+	cols, err := Columns(&person{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []string{"Street"}, cols)
+}
+
+func TestColumnsAddsComplexTypesWhenStructTag(t *testing.T) {
+	type person struct {
+		Address struct {
+			Street string `db:"address.street"`
+		}
+	}
+
+	cols, err := Columns(&person{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []string{"address.street"}, cols)
+}
+
+func TestColumnsDoesNotAddStructTag(t *testing.T) {
+	type person struct {
+		Address struct {
+			Street string `db:"address.street"`
 		} `db:"address"`
 	}
 
 	cols, err := Columns(&person{})
 	assert.NoError(t, err)
-	assert.EqualValues(t, []string{"address", "Street"}, cols)
+	assert.EqualValues(t, []string{"address.street"}, cols)
+}
+
+func TestColumnsStrictAddsComplexTypesWhenStructTag(t *testing.T) {
+	type person struct {
+		Address struct {
+			Street string `db:"address.street"`
+		}
+	}
+
+	cols, err := ColumnsStrict(&person{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []string{"address.street"}, cols)
+}
+
+func TestColumnsStrictDoesNotAddComplexTypesWhenNoStructTag(t *testing.T) {
+	type person struct {
+		Address struct {
+			Street string
+		}
+	}
+
+	cols, err := ColumnsStrict(&person{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []string{}, cols)
+}
+
+func TestColumnsStrictDoesNotAddComplexTypesWhenStructTagIgnored(t *testing.T) {
+	type person struct {
+		Address struct {
+			Street string `db:"address.street"`
+		} `db:"-"`
+	}
+
+	cols, err := ColumnsStrict(&person{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []string{}, cols)
 }
 
 func TestColumnsIgnoresComplexTypesWhenNoStructTag(t *testing.T) {

--- a/columns_test.go
+++ b/columns_test.go
@@ -72,7 +72,7 @@ func TestColumnsAddsComplexTypesWhenStructTag(t *testing.T) {
 
 	cols, err := Columns(&person{})
 	assert.NoError(t, err)
-	assert.EqualValues(t, []string{"address"}, cols)
+	assert.EqualValues(t, []string{"address", "Street"}, cols)
 }
 
 func TestColumnsIgnoresComplexTypesWhenNoStructTag(t *testing.T) {
@@ -84,7 +84,7 @@ func TestColumnsIgnoresComplexTypesWhenNoStructTag(t *testing.T) {
 
 	cols, err := Columns(&person{})
 	assert.NoError(t, err)
-	assert.EqualValues(t, []string{}, cols)
+	assert.EqualValues(t, []string{"Street"}, cols)
 }
 
 func TestColumnsExcludesFields(t *testing.T) {

--- a/examples_values_columns_test.go
+++ b/examples_values_columns_test.go
@@ -22,6 +22,31 @@ func ExampleValues() {
 	// [1 Brett]
 }
 
+func ExampleValues_nested() {
+	type Address struct {
+		Street string
+		City   string
+	}
+
+	person := struct {
+		ID   int
+		Name string
+		Address
+	}{
+		Name: "Brett",
+		ID:   1,
+		Address: Address{
+			City: "San Francisco",
+		},
+	}
+
+	cols := []string{"Name", "City"}
+	vals, _ := scan.Values(cols, &person)
+	fmt.Printf("%+v", vals)
+	// Output:
+	// [Brett San Francisco]
+}
+
 func ExampleColumns() {
 	var person struct {
 		ID   int `db:"person_id"`
@@ -58,4 +83,52 @@ func ExampleColumnsStrict() {
 	fmt.Printf("%+v", cols)
 	// Output:
 	// [id age]
+}
+
+func ExampleColumnsNested() {
+	var person struct {
+		ID      int    `db:"person.id"`
+		Name    string `db:"person.name"`
+		Company struct {
+			ID   int `db:"company.id"`
+			Name string
+		}
+	}
+
+	cols, _ := scan.Columns(&person)
+	fmt.Printf("%+v", cols)
+	// Output:
+	// [person.id person.name company.id Name]
+}
+
+func ExampleColumnsNestedStrict() {
+	var person struct {
+		ID      int    `db:"person.id"`
+		Name    string `db:"person.name"`
+		Company struct {
+			ID   int `db:"company.id"`
+			Name string
+		}
+	}
+
+	cols, _ := scan.ColumnsStrict(&person)
+	fmt.Printf("%+v", cols)
+	// Output:
+	// [person.id person.name company.id]
+}
+
+func ExampleColumnsNested_exclude() {
+	var person struct {
+		ID      int    `db:"person.id"`
+		Name    string `db:"person.name"`
+		Company struct {
+			ID   int    `db:"-"`
+			Name string `db:"company.name"`
+		}
+	}
+
+	cols, _ := scan.Columns(&person)
+	fmt.Printf("%+v", cols)
+	// Output:
+	// [person.id person.name company.name]
 }

--- a/values_test.go
+++ b/values_test.go
@@ -33,6 +33,26 @@ func TestValuesScansDBTags(t *testing.T) {
 	assert.EqualValues(t, []interface{}{"Brett"}, vals)
 }
 
+func TestValuesScansNestedFields(t *testing.T) {
+	type Address struct {
+		Street string
+		City   string
+	}
+
+	type Person struct {
+		Name string
+		Age  int
+		Address
+	}
+
+	p := &Person{Name: "Brett", Address: Address{Street: "123 Main St", City: "San Francisco"}}
+
+	vals, err := Values([]string{"Name", "Street", "City"}, p)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []interface{}{"Brett", "123 Main St", "San Francisco"}, vals)
+}
+
 func TestValuesReturnsErrorWhenPassingNonPointer(t *testing.T) {
 	_, err := Values([]string{"Name"}, "")
 	require.Error(t, err)
@@ -80,7 +100,7 @@ func TestValuesReadsFromCacheFirst(t *testing.T) {
 	}
 
 	v := reflect.Indirect(reflect.ValueOf(&person))
-	valuesCache.Store(v, map[string]int{"Name": 0})
+	valuesCache.Store(v, map[string][]int{"Name": {0}})
 
 	vals, err := Values([]string{"Name"}, &person)
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #54.

Support for embedded structs has been added for both `scan.Columns` and `scan.Values` through good old recursion.
I just to want to explain a little bit more in detail my changes to `scan.Values`.

So first of all I opted to store a slice of ints in the cache map, representing the [struct field index](https://pkg.go.dev/reflect#Value.FieldByIndex). This allows us to directly access the corresponding struct field value while iterating over the provided `cols` in the main `Values` function.
Hopefully this image of the debugger which shows the value of `fields := loadFields(model)` can make it more clear:

<img width="736" alt="Screenshot 2023-07-06 at 01 26 55 1" src="https://github.com/blockloop/scan/assets/80476005/792b409e-dc32-404b-ac0b-a1e707a0ef5e">


The test that was run for the image above:

```
func TestValuesScansNestedFields(t *testing.T) {
	type Address struct {
		Street string
		City   string
	}

	type Person struct {
		Name string
		Age  int
		Address
	}

	p := &Person{Name: "Brett", Address: Address{Street: "123 Main St", City: "San Francisco"}}

	vals, err := Values([]string{"Name", "Street", "City"}, p)
	require.NoError(t, err)

	assert.EqualValues(t, []interface{}{"Brett", "123 Main St", "San Francisco"}, vals)
}
```