### PR TITLE
fix: Use model.Type() as cache key instead of model itself

### DIFF
--- a/columns.go
+++ b/columns.go
@@ -31,6 +31,11 @@ var (
 
 var columnsCache cache = &sync.Map{}
 
+type cacheKey struct {
+	Type   reflect.Type
+	Strict bool
+}
+
 // Columns scans a struct and returns a list of strings
 // that represent the assumed column names based on the
 // db struct tag, or the field name. Any field or struct
@@ -53,7 +58,9 @@ func columns(v interface{}, strict bool, excluded ...string) ([]string, error) {
 		return nil, fmt.Errorf("columns: %w", err)
 	}
 
-	if cache, ok := columnsCache.Load(model); ok {
+	key := cacheKey{model.Type(), strict}
+
+	if cache, ok := columnsCache.Load(key); ok {
 		cached := cache.([]string)
 		res := make([]string, 0, len(cached))
 
@@ -76,7 +83,7 @@ func columns(v interface{}, strict bool, excluded ...string) ([]string, error) {
 
 	names := columnNames(model, strict, excluded...)
 	toCache := append(names, excluded...)
-	columnsCache.Store(model, toCache)
+	columnsCache.Store(key, toCache)
 	return names, nil
 }
 

--- a/values.go
+++ b/values.go
@@ -32,7 +32,7 @@ func Values(cols []string, v interface{}) ([]interface{}, error) {
 }
 
 func loadFields(val reflect.Value) map[string][]int {
-	if cache, cached := valuesCache.Load(val); cached {
+	if cache, cached := valuesCache.Load(val.Type()); cached {
 		return cache.(map[string][]int)
 	}
 	return writeFieldsCache(val)
@@ -41,7 +41,7 @@ func loadFields(val reflect.Value) map[string][]int {
 func writeFieldsCache(val reflect.Value) map[string][]int {
 	m := map[string][]int{}
 	writeFields(val, m, []int{})
-	valuesCache.Store(val, m)
+	valuesCache.Store(val.Type(), m)
 	return m
 }
 

--- a/values_test.go
+++ b/values_test.go
@@ -99,10 +99,10 @@ func TestValuesReadsFromCacheFirst(t *testing.T) {
 		Name: "Brett",
 	}
 
-	v := reflect.Indirect(reflect.ValueOf(&person))
-	valuesCache.Store(v, map[string][]int{"Name": {0}})
+	v := reflect.Indirect(reflect.ValueOf(&person)).Type()
+	valuesCache.Store(v, map[string][]int{"fake": {0}})
 
-	vals, err := Values([]string{"Name"}, &person)
+	vals, err := Values([]string{"fake"}, &person)
 	require.NoError(t, err)
 	assert.EqualValues(t, []interface{}{"Brett"}, vals)
 }


### PR DESCRIPTION
Fix for #61 

> Type values are comparable, such as with the == operator, so they can be used as map keys. Two Type values are equal if they represent identical types.

From https://pkg.go.dev/reflect#Type