### PR TITLE
fix: Allow valid sql types to be used by Columns and Values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .coverprofile
+.idea

--- a/columns.go
+++ b/columns.go
@@ -100,7 +100,7 @@ func columnNames(model reflect.Value, strict bool, excluded ...string) []string 
 
 		typeField := model.Type().Field(i)
 
-		if typeField.Type.Kind() == reflect.Struct || isValidSqlValue(valField) {
+		if typeField.Type.Kind() == reflect.Struct && !isValidSqlValue(valField) {
 			embeddedNames := columnNames(valField, strict, excluded...)
 			names = append(names, embeddedNames...)
 			continue
@@ -121,7 +121,7 @@ func columnNames(model reflect.Value, strict bool, excluded ...string) []string 
 			continue
 		}
 
-		if supportedColumnType(valField.Kind()) {
+		if supportedColumnType(valField.Kind()) || isValidSqlValue(valField) {
 			names = append(names, fieldName)
 		}
 	}
@@ -174,9 +174,5 @@ func isValidSqlValue(v reflect.Value) bool {
 	}
 
 	valuerType := reflect.TypeOf((*driver.Valuer)(nil)).Elem()
-	if v.Type().Implements(valuerType) {
-		return true
-	}
-
-	return false
+	return v.Type().Implements(valuerType)
 }

--- a/values.go
+++ b/values.go
@@ -50,15 +50,16 @@ func writeFields(val reflect.Value, m map[string][]int, index []int) {
 	numfield := val.NumField()
 
 	for i := 0; i < numfield; i++ {
-		if !val.Field(i).CanSet() {
+		valField := val.Field(i)
+		if !valField.CanSet() {
 			continue
 		}
 
 		field := typ.Field(i)
 		fieldIndex := append(index, field.Index...)
 
-		if field.Type.Kind() == reflect.Struct {
-			writeFields(val.Field(i), m, fieldIndex)
+		if field.Type.Kind() == reflect.Struct && !isValidSqlValue(valField) {
+			writeFields(valField, m, fieldIndex)
 			continue
 		}
 


### PR DESCRIPTION
Due to the feature change that allowed nested structs to be passed (https://github.com/blockloop/scan/pull/60), two types of data fields were no longer included by calls to `Columns` and `Values` that we use:

1. `time.Time` values
2. structs implementing the `driver.Valuer` interface

I believe both of these should skip further recursion and be recognized as valid types to be used with this library.

- The sql/driver library recognizes `time.Time` as valid column type
  - https://cs.opensource.google/go/go/+/refs/tags/go1.20.6:src/database/sql/driver/types.go;l=176
- Golang's sql package specifically maintains conversion for it here
  - https://github.com/golang/go/blob/master/src/database/sql/convert.go#L271-L288
- Implementing `driver.Valuer` allows for implicit conversion to valid sql statements
  - https://pkg.go.dev/database/sql/driver#Valuer

Happy to talk through any of it, please let me know if you have any feedback. Thanks!