### PR TITLE
fix: Columns and Values should recognize pointer values too

### DIFF
--- a/columns.go
+++ b/columns.go
@@ -121,7 +121,7 @@ func columnNames(model reflect.Value, strict bool, excluded ...string) []string 
 			continue
 		}
 
-		if supportedColumnType(valField.Kind()) || isValidSqlValue(valField) {
+		if supportedColumnType(valField) || isValidSqlValue(valField) {
 			names = append(names, fieldName)
 		}
 	}
@@ -152,13 +152,16 @@ func reflectValue(v interface{}) (reflect.Value, error) {
 	return vVal, nil
 }
 
-func supportedColumnType(k reflect.Kind) bool {
-	switch k {
+func supportedColumnType(v reflect.Value) bool {
+	switch v.Kind() {
 	case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
 		reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32,
 		reflect.Uint64, reflect.Float32, reflect.Float64, reflect.Interface,
 		reflect.String:
 		return true
+	case reflect.Ptr:
+		ptrVal := reflect.New(v.Type().Elem())
+		return supportedColumnType(ptrVal.Elem())
 	default:
 		return false
 	}
@@ -169,6 +172,11 @@ func isValidSqlValue(v reflect.Value) bool {
 	// 1. It returns true for sql.driver's type check for types like time.Time
 	// 2. It implements the driver.Valuer interface allowing conversion directly
 	//    into sql statements
+	if v.Kind() == reflect.Ptr {
+		ptrVal := reflect.New(v.Type().Elem())
+		return isValidSqlValue(ptrVal.Elem())
+	}
+
 	if driver.IsValue(v.Interface()) {
 		return true
 	}

--- a/columns_test.go
+++ b/columns_test.go
@@ -272,10 +272,32 @@ func TestColumnsStoresOneCacheEntryPerInstance(t *testing.T) {
 	assert.Equal(t, 1, after-before, "Cache size grew unexpectedly")
 }
 
-func TestValuesWorkWithValidSqlValueTypes(t *testing.T) {
+func TestColumnsReturnsStructTagsWithPointers(t *testing.T) {
+	type personUpdate struct {
+		Name *string `db:"name"`
+	}
+
+	cols, err := Columns(&personUpdate{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []string{"name"}, cols)
+}
+
+func TestColumnsWorkWithValidSqlValueTypes(t *testing.T) {
 	type coupon struct {
 		Value   int       `db:"value"`
 		Expires time.Time `db:"expires"`
+	}
+
+	c := &coupon{}
+	cols, err := Columns(c)
+	assert.NoError(t, err)
+	assert.EqualValues(t, []string{"value", "expires"}, cols)
+}
+
+func TestColumnsWorkWithPointerValidSqlTypes(t *testing.T) {
+	type coupon struct {
+		Value   int        `db:"value"`
+		Expires *time.Time `db:"expires"`
 	}
 
 	c := &coupon{}
@@ -309,4 +331,8 @@ func BenchmarkColumnsLargeStruct(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Columns(ls)
 	}
+}
+
+func ptr(s string) *string {
+	return &s
 }

--- a/values_test.go
+++ b/values_test.go
@@ -34,6 +34,30 @@ func TestValuesScansDBTags(t *testing.T) {
 	assert.EqualValues(t, []interface{}{"Brett"}, vals)
 }
 
+func TestValuesScansPointerDBTags(t *testing.T) {
+	type person struct {
+		Name *string `db:"n"`
+	}
+
+	p := &person{Name: ptr("Brett")}
+	vals, err := Values([]string{"n"}, p)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []interface{}{ptr("Brett")}, vals)
+}
+
+func TestValuesReturnsNilPointers(t *testing.T) {
+	type person struct {
+		Name *string `db:"n"`
+	}
+
+	p := &person{Name: nil}
+	vals, err := Values([]string{"n"}, p)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []interface{}{(*string)(nil)}, vals)
+}
+
 func TestValuesScansNestedFields(t *testing.T) {
 	type Address struct {
 		Street string
@@ -122,6 +146,22 @@ func TestValuesValidSqlTypes(t *testing.T) {
 	vals, err := Values([]string{"Value", "Expires"}, c)
 	require.NoError(t, err)
 	assert.EqualValues(t, []interface{}{25, tNow}, vals)
+}
+
+func TestValuesValidPointerSqlTypes(t *testing.T) {
+	tNow := time.Now()
+	type coupon struct {
+		Value   int
+		Expires *time.Time
+	}
+	c := &coupon{
+		Value:   25,
+		Expires: &tNow,
+	}
+
+	vals, err := Values([]string{"Value", "Expires"}, c)
+	require.NoError(t, err)
+	assert.EqualValues(t, []interface{}{25, &tNow}, vals)
 }
 
 func TestValuesDriverValuerImplementers(t *testing.T) {


### PR DESCRIPTION
**Use case**: For some nullable sql columns we use pointers to represent the field in our data models. This fix allows us to continue to use scan for these types of operations. This previously worked in v1.3 and regressed with the nested struct feature.

I hope the tests added are illustrative of our use case and make sense. Please do let me know if there are any questions- thanks!!