### PR TITLE
fix: Columns and Values should recognize Slice values too

### DIFF
--- a/columns.go
+++ b/columns.go
@@ -159,7 +159,7 @@ func supportedColumnType(v reflect.Value) bool {
 		reflect.Uint64, reflect.Float32, reflect.Float64, reflect.Interface,
 		reflect.String:
 		return true
-	case reflect.Ptr:
+	case reflect.Ptr, reflect.Slice, reflect.Array:
 		ptrVal := reflect.New(v.Type().Elem())
 		return supportedColumnType(ptrVal.Elem())
 	default:

--- a/columns_test.go
+++ b/columns_test.go
@@ -282,6 +282,26 @@ func TestColumnsReturnsStructTagsWithPointers(t *testing.T) {
 	assert.EqualValues(t, []string{"name"}, cols)
 }
 
+func TestColumnsReturnsStructTagsWithArrays(t *testing.T) {
+	type personGetFilter struct {
+		PersonIDs *string `db:"id"`
+	}
+
+	cols, err := Columns(&personGetFilter{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []string{"id"}, cols)
+}
+
+func TestColumnsReturnsStructTagsWithPointersToArrays(t *testing.T) {
+	type personGetFilter struct {
+		PersonIDs *[]string `db:"id"`
+	}
+
+	cols, err := Columns(&personGetFilter{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, []string{"id"}, cols)
+}
+
 func TestColumnsWorkWithValidSqlValueTypes(t *testing.T) {
 	type coupon struct {
 		Value   int       `db:"value"`

--- a/values_test.go
+++ b/values_test.go
@@ -58,6 +58,42 @@ func TestValuesReturnsNilPointers(t *testing.T) {
 	assert.EqualValues(t, []interface{}{(*string)(nil)}, vals)
 }
 
+func TestValuesScansSliceDBTags(t *testing.T) {
+	type person struct {
+		Names []string `db:"n"`
+	}
+
+	p := &person{Names: []string{"Brett", "The Big B"}}
+	vals, err := Values([]string{"n"}, p)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []interface{}{[]string{"Brett", "The Big B"}}, vals)
+}
+
+func TestValuesScansNilSliceDBTags(t *testing.T) {
+	type person struct {
+		Names []string `db:"n"`
+	}
+
+	p := &person{}
+	vals, err := Values([]string{"n"}, p)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []interface{}{[]string(nil)}, vals)
+}
+
+func TestValuesScansPointerToSliceDBTags(t *testing.T) {
+	type personUpdate struct {
+		Names *[]string `db:"n"`
+	}
+	names := []string{"Jack", "J Man"}
+	p := &personUpdate{Names: &names}
+	vals, err := Values([]string{"n"}, p)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []interface{}{&names}, vals)
+}
+
 func TestValuesScansNestedFields(t *testing.T) {
 	type Address struct {
 		Street string


### PR DESCRIPTION
Continues work done in #67 with the same rationale - this worked in 1.3 and no longer works in 2.0. This fix allows us to continue to use `scan` to pull the column names and values out for `slice` and `array` elements.

A more concerete example:

We use arrays for lots of filter operations - for example if I wanted to find all Widgets owned by a group of users, I might define
```golang
type WidgetFilter struct {
    OwnerIDs []string `db:"owner_id"`
}
```

and then 
```golang
WidgetFilter{OwnerIDs: []string{"123", "456"}
```
would be evaluated as
```golang
select * from widgets where owner_id in (?, ?), ["123", "456"]
```

We're hoping to release some of this stuff that builds on `scan` soon!