### PR TITLE
Added support for custom columns names mapper functions

### DIFF
--- a/columns.go
+++ b/columns.go
@@ -28,6 +28,11 @@ var (
 	// the struct does not have a field that matches the column
 	// specified.
 	ErrStructFieldMissing = errors.New("struct field missing")
+
+	// ColumnsMapper transforms struct/map field names
+	// into the database column names.
+	// E.g. you can set function for convert CamelCase into snake_case
+	ColumnsMapper = func(name string) string { return name }
 )
 
 var columnsCache cache = &sync.Map{}
@@ -106,7 +111,7 @@ func columnNames(model reflect.Value, strict bool, excluded ...string) []string 
 			continue
 		}
 
-		fieldName := typeField.Name
+		fieldName := ColumnsMapper(typeField.Name)
 		if tag, hasTag := typeField.Tag.Lookup(dbTag); hasTag {
 			if tag == "-" {
 				continue

--- a/scanner.go
+++ b/scanner.go
@@ -27,6 +27,10 @@ var (
 	// OnAutoCloseError can be used to log errors which are returned from rows.Close()
 	// By default this is a NOOP function
 	OnAutoCloseError = func(error) {}
+
+	// ScannerMapper transforms database field names into struct/map field names
+	// E.g. you can set function for convert snake_case into CamelCase
+	ScannerMapper = func(name string) string { return cases.Title(language.English).String(name) }
 )
 
 // Row scans a single row into a single variable. It requires that you use
@@ -174,7 +178,7 @@ func structPointers(sliceItem reflect.Value, cols []string, strict bool) []inter
 			if strict {
 				fieldVal = reflect.ValueOf(nil)
 			} else {
-				fieldVal = sliceItem.FieldByName(cases.Title(language.English).String(colName))
+				fieldVal = sliceItem.FieldByName(ScannerMapper(colName))
 			}
 		}
 		if !fieldVal.IsValid() || !fieldVal.CanSet() {


### PR DESCRIPTION
Added support for custom column names mappers functions. It is useful feature if you using CamelCase in Go struct fields and snake_case in db columns. You don't need to define "db" flag.